### PR TITLE
Fixing deeplink to item details

### DIFF
--- a/websites/app/src/pages/Home/EntriesList/Entry.tsx
+++ b/websites/app/src/pages/Home/EntriesList/Entry.tsx
@@ -155,6 +155,7 @@ const Entry = React.memo(
         newParams.append('itemdetails', item.id);
         return newParams;
       });
+      scrollTop();
     }, [setSearchParams, item.id]);
 
     const getPropValue = (label: string) => {

--- a/websites/app/src/pages/Home/index.tsx
+++ b/websites/app/src/pages/Home/index.tsx
@@ -204,7 +204,7 @@ const Home: React.FC = () => {
 
   // If missing search params, insert defaults.
   useEffect(() => {
-    if (searchParams.get('page') === 'rewards' || searchParams.get('attachment') || searchParams.get('itemdetails' )) {
+    if (searchParams.get('page') === 'rewards' || searchParams.get('attachment') || searchParams.get('itemdetails')) {
       return
     }
     
@@ -243,6 +243,8 @@ const Home: React.FC = () => {
       ? Math.ceil(currentItemCount / ITEMS_PER_PAGE)
       : null // in complex query, cannot provide this information
 
+  const isItemDetailsOpen = searchParams.get('itemdetails');
+
   return (
     <Container>
       <Navbar />
@@ -252,22 +254,26 @@ const Home: React.FC = () => {
         <EvidenceAttachmentDisplay />
       ) : (
         <>
-          <SearchAndRegistryDetailsAndSubmitContainer>
-            <Search />
-            <RegistryDetailsAndSubmitContainer>
-              <RegistryDetails />
-              <SubmitButton />
-            </RegistryDetailsAndSubmitContainer>
-          </SearchAndRegistryDetailsAndSubmitContainer>
+          {!isItemDetailsOpen && (
+            <>
+              <SearchAndRegistryDetailsAndSubmitContainer>
+                <Search />
+                <RegistryDetailsAndSubmitContainer>
+                  <RegistryDetails />
+                  <SubmitButton />
+                </RegistryDetailsAndSubmitContainer>
+              </SearchAndRegistryDetailsAndSubmitContainer>
 
-          <Filters />
+              <Filters />
 
-          {searchLoading || !searchData ? (
-            <LoadingItems />
-          ) : (
-            <EntriesList {...{searchData}} />
+              {searchLoading || !searchData ? (
+                <LoadingItems />
+              ) : (
+                <EntriesList {...{ searchData }} />
+              )}
+              <Pagination {...{ totalPages }} />
+            </>
           )}
-          <Pagination {...{totalPages}} />
 
           {isDetailsModalOpen && <DetailsModal />}
           {isRegistryDetailsModalOpen && <RegistryDetailsModal />}


### PR DESCRIPTION
Proposing a simple fix to the deeplink problem by fetching itemDetails from the URL if present to show only the item in focus. This also allows for a snappy display of just the item itself, without loading all the items in the background.

<img width="1852" alt="image" src="https://github.com/user-attachments/assets/191c204c-9ecc-4634-9c2d-acb3ab571bbf" />

<img width="1904" alt="image" src="https://github.com/user-attachments/assets/b353767c-e9cb-4f04-a620-f9b1037fd1f1" />
