### PR TITLE
docs(app): add Scout Skills and UI updates

### DIFF
--- a/websites/app/src/index.html
+++ b/websites/app/src/index.html
@@ -19,9 +19,15 @@
     <meta name="ai-agent-instructions" content="/llms.txt" />
     <link
       rel="alternate"
-      type="text/markdown"
+      type="text/plain"
       href="/llms.txt"
       title="Scout agent instructions"
+    />
+    <link
+      rel="help"
+      type="text/plain"
+      href="/llms-full.txt"
+      title="Scout full agent context"
     />
     <link
       rel="help"

--- a/websites/app/src/index.html
+++ b/websites/app/src/index.html
@@ -16,6 +16,19 @@
       name="keywords"
       content="dispute resolution, decentralized arbitration, Kleros, blockchain court"
     />
+    <meta name="ai-agent-instructions" content="/llms.txt" />
+    <link
+      rel="alternate"
+      type="text/markdown"
+      href="/llms.txt"
+      title="Scout agent instructions"
+    />
+    <link
+      rel="help"
+      type="text/markdown"
+      href="/scout-agent-context.md"
+      title="Scout agent context"
+    />
     <link rel="shortcut icon" type="image/svg+xml" href="./favicon.ico" />
     <title>Scout · Kleros</title>
   </head>

--- a/websites/app/src/layout/Footer/index.tsx
+++ b/websites/app/src/layout/Footer/index.tsx
@@ -93,13 +93,43 @@ const StyledToSLink = styled(Link)`
   }
 `;
 
+const FooterLinks = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  justify-content: center;
+`;
+
+const StyledAgentLink = styled.a`
+  ${hoverShortTransitionTiming}
+  color: ${({ theme }) => theme.white}BF;
+  text-decoration: none;
+  font-size: 14px;
+  font-family: "Manrope", sans-serif;
+
+  &:hover {
+    color: ${({ theme }) => theme.white};
+    text-decoration: underline;
+  }
+`;
+
 const Footer: React.FC = () => (
   <Container>
     <Inner>
       <SecuredByKleros />
-      <StyledToSLink to="/terms-of-service">
-        Terms of Service
-      </StyledToSLink>
+      <FooterLinks>
+        <StyledToSLink to="/terms-of-service">
+          Terms of Service
+        </StyledToSLink>
+        <StyledAgentLink
+          href="/llms.txt"
+          rel="help"
+          title="Agent instructions for Scout submissions"
+        >
+          Agent instructions
+        </StyledAgentLink>
+      </FooterLinks>
       <SocialMedia />
     </Inner>
   </Container>

--- a/websites/app/src/layout/Footer/index.tsx
+++ b/websites/app/src/layout/Footer/index.tsx
@@ -125,9 +125,9 @@ const Footer: React.FC = () => (
         <StyledAgentLink
           href="/llms.txt"
           rel="help"
-          title="Agent instructions for Scout submissions"
+          title="LLM instructions for Scout agents"
         >
-          Agent instructions
+          For agents
         </StyledAgentLink>
       </FooterLinks>
       <SocialMedia />

--- a/websites/app/src/layout/Header/HeaderNav.tsx
+++ b/websites/app/src/layout/Header/HeaderNav.tsx
@@ -186,7 +186,7 @@ const HeaderNav: React.FC = () => {
 
       <StyledNavLink to="/rewards">Active Rewards</StyledNavLink>
 
-      <StyledNavLink to="/guide">Quick Guide</StyledNavLink>
+      <StyledNavLink to="/guide">Learn · AI</StyledNavLink>
     </Container>
   );
 };

--- a/websites/app/src/layout/Header/HeaderNav.tsx
+++ b/websites/app/src/layout/Header/HeaderNav.tsx
@@ -186,7 +186,7 @@ const HeaderNav: React.FC = () => {
 
       <StyledNavLink to="/rewards">Active Rewards</StyledNavLink>
 
-      <StyledNavLink to="/guide">Learn · AI</StyledNavLink>
+      <StyledNavLink to="/guide">Guide & Skills</StyledNavLink>
     </Container>
   );
 };

--- a/websites/app/src/layout/Header/navbar/index.tsx
+++ b/websites/app/src/layout/Header/navbar/index.tsx
@@ -231,7 +231,7 @@ const NavBar: React.FC = () => {
 
               <LightButton
                 isMobileNavbar={true}
-                text="Quick Guide"
+                text="Learn · AI"
                 onClick={() => {
                   navigate("/guide");
                   toggleIsOpen();

--- a/websites/app/src/layout/Header/navbar/index.tsx
+++ b/websites/app/src/layout/Header/navbar/index.tsx
@@ -231,7 +231,7 @@ const NavBar: React.FC = () => {
 
               <LightButton
                 isMobileNavbar={true}
-                text="Learn · AI"
+                text="Guide & Skills"
                 onClick={() => {
                   navigate("/guide");
                   toggleIsOpen();

--- a/websites/app/src/pages/Guide/index.tsx
+++ b/websites/app/src/pages/Guide/index.tsx
@@ -437,14 +437,17 @@ scope:
     </AgentTerminal>
 
     <AgentIntro>
-      <AgentTitle>Copy-paste prompt</AgentTitle>
+      <AgentTitle>Agent quickstart</AgentTitle>
       <AgentDescription>
-        Paste this into an agent that does not automatically discover Scout instructions.
+        Fetch the context directly from this deployment.
       </AgentDescription>
       <AgentPromptBlock
         readOnly
-        aria-label="Copy-paste prompt for agents"
-        value={`Before working on Kleros Scout, fetch and read the Scout agent instructions at ${window.location.origin}/llms.txt. Then follow the required read order in that file and do not submit, challenge, or analyze Scout registry items until the canonical kleros-skills references are loaded.`}
+        aria-label="Agent quickstart commands"
+        value={`curl -fsSL ${window.location.origin}/skill.md
+curl -fsSL ${window.location.origin}/llms.txt
+curl -fsSL ${window.location.origin}/scout-agent-context.md
+curl -fsSL https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/SKILL.md`}
         onFocus={(event) => event.currentTarget.select()}
       />
     </AgentIntro>

--- a/websites/app/src/pages/Guide/index.tsx
+++ b/websites/app/src/pages/Guide/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import styled, { css } from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { landscapeStyle, MAX_WIDTH_LANDSCAPE } from "styles/landscapeStyle";
@@ -51,6 +51,47 @@ const Title = styled.h1`
 const Subtitle = styled.p`
   margin: 4px 0 0 0;
   color: ${({ theme }) => theme.secondaryText};
+`;
+
+const AudienceSelector = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 28px;
+  padding: 16px;
+  border: 1px solid ${({ theme }) => theme.stroke};
+  border-radius: 12px;
+  background: ${({ theme }) => theme.whiteLowOpacitySubtle};
+`;
+
+const SelectorLabel = styled.span`
+  color: ${({ theme }) => theme.secondaryText};
+  font-size: 14px;
+`;
+
+const SelectorOptions = styled.div`
+  display: flex;
+  gap: 8px;
+`;
+
+const SelectorButton = styled.button<{ $isSelected: boolean }>`
+  ${hoverShortTransitionTiming}
+  min-width: 86px;
+  min-height: 36px;
+  padding: 8px 14px;
+  border-radius: 7px;
+  border: 1px solid ${({ $isSelected, theme }) => ($isSelected ? theme.primaryBlue : theme.stroke)};
+  background: ${({ $isSelected, theme }) => ($isSelected ? `${theme.primaryBlue}1F` : "transparent")};
+  color: ${({ $isSelected, theme }) => ($isSelected ? theme.primaryText : theme.secondaryText)};
+  font: inherit;
+  font-size: 14px;
+  cursor: pointer;
+
+  &:hover {
+    color: ${({ theme }) => theme.primaryText};
+    border-color: ${({ theme }) => theme.primaryText};
+  }
 `;
 
 const CardRow = styled.div`
@@ -161,6 +202,76 @@ const AttentionLabel = styled.label`
   color: ${({ theme }) => theme.tintYellow};
 `;
 
+const AgentPanel = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  max-width: 760px;
+`;
+
+const AgentIntro = styled.div`
+  padding: 24px;
+  border: 1px solid ${({ theme }) => theme.stroke};
+  border-radius: 12px;
+  background: ${({ theme }) => theme.whiteLowOpacitySubtle};
+`;
+
+const AgentTitle = styled.h2`
+  margin: 0 0 8px;
+  font-size: 20px;
+  color: ${({ theme }) => theme.primaryText};
+`;
+
+const AgentDescription = styled.p`
+  margin: 0;
+  color: ${({ theme }) => theme.secondaryText};
+  line-height: 1.45;
+`;
+
+const AgentLinkGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+`;
+
+const AgentLinkCard = styled.a`
+  ${hoverShortTransitionTiming}
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 20px;
+  min-height: 132px;
+  border-radius: 12px;
+  border: 1px solid ${({ theme }) => theme.stroke};
+  color: ${({ theme }) => theme.primaryText};
+  text-decoration: none;
+  background: transparent;
+
+  &:hover {
+    transform: scale(1.02);
+    border-color: ${({ theme }) => theme.primary};
+    box-shadow: ${({ theme }) => theme.shadowDropdown};
+  }
+`;
+
+const AgentLinkTitle = styled.span`
+  font-size: 16px;
+  font-weight: 600;
+`;
+
+const AgentLinkDescription = styled.span`
+  color: ${({ theme }) => theme.tertiaryText};
+  font-size: 14px;
+  line-height: 1.35;
+`;
+
+const AgentChecklist = styled.ul`
+  margin: 0;
+  padding-left: 20px;
+  color: ${({ theme }) => theme.secondaryText};
+  line-height: 1.45;
+`;
+
 const SubmittingItem = () => (
   <SectionContainer>
     <SectionHeader>Submitting an Item</SectionHeader>
@@ -228,7 +339,52 @@ const ChallengePhase = () => (
   </SectionContainer>
 );
 
+const AgentGuide = () => (
+  <AgentPanel>
+    <AgentIntro>
+      <AgentTitle>I am an agent.</AgentTitle>
+      <AgentDescription>
+        Start with the machine-readable instructions, then load the canonical Kleros Curate
+        skill references before acting on Scout submissions, challenges, evidence, appeals,
+        registry data, token lists, address tags, or CDN mappings.
+      </AgentDescription>
+    </AgentIntro>
+
+    <AgentLinkGrid>
+      <AgentLinkCard href="/llms.txt" rel="help">
+        <AgentLinkTitle>Start here: /llms.txt</AgentLinkTitle>
+        <AgentLinkDescription>
+          Short Scout-specific entrypoint with required read order and safety rules.
+        </AgentLinkDescription>
+      </AgentLinkCard>
+      <AgentLinkCard href="/scout-agent-context.md" rel="help">
+        <AgentLinkTitle>Expanded Scout context</AgentLinkTitle>
+        <AgentLinkDescription>
+          Local workflow guide for the four supported Scout registries on Gnosis.
+        </AgentLinkDescription>
+      </AgentLinkCard>
+      <AgentLinkCard href="https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/SKILL.md">
+        <AgentLinkTitle>Canonical Kleros Curate skill</AgentLinkTitle>
+        <AgentLinkDescription>
+          Source of truth if any local Scout guidance conflicts with kleros-skills.
+        </AgentLinkDescription>
+      </AgentLinkCard>
+    </AgentLinkGrid>
+
+    <AgentIntro>
+      <AgentTitle>Do not proceed until these checks pass.</AgentTitle>
+      <AgentChecklist>
+        <li>Confirm the registry is one of the four Scout registry addresses.</li>
+        <li>Read scout-registries.md and light-curate.md together.</li>
+        <li>Use Scout seed templates first, then cross-check current MetaEvidence.</li>
+        <li>Read the current policy and compute deposits from fresh onchain reads.</li>
+      </AgentChecklist>
+    </AgentIntro>
+  </AgentPanel>
+);
+
 const QuickGuidePage: React.FC = () => {
+  const [audience, setAudience] = useState<'human' | 'agent'>('human');
   const navigate = useNavigate();
 
   const handleRewardsClick = () => {
@@ -241,51 +397,79 @@ const QuickGuidePage: React.FC = () => {
       <Header>
         <BookCircleIcon />
         <div>
-          <Title>Quick Guide</Title>
+          <Title>Learn · AI</Title>
           <Subtitle>
             Keep the community safe, earn bounties, and have fun in Kleros Scout!
           </Subtitle>
         </div>
       </Header>
 
-      <Frame>
-        <SubmittingItem />
-        <ChallengingSubmission />
-        <ChallengePhase />
-      </Frame>
+      <AudienceSelector aria-label="Choose guide audience">
+        <SelectorLabel>I am:</SelectorLabel>
+        <SelectorOptions>
+          <SelectorButton
+            type="button"
+            $isSelected={audience === 'human'}
+            onClick={() => setAudience('human')}
+            aria-pressed={audience === 'human'}
+          >
+            Human
+          </SelectorButton>
+          <SelectorButton
+            type="button"
+            $isSelected={audience === 'agent'}
+            onClick={() => setAudience('agent')}
+            aria-pressed={audience === 'agent'}
+          >
+            Agent
+          </SelectorButton>
+        </SelectorOptions>
+      </AudienceSelector>
 
-      <CardRow>
-        <ClickableInfoCard onClick={handleRewardsClick}>
-          <BountiesIcon />
-          <CardTitleAndDescription>
-            <CardTitle>Bounties</CardTitle>
-            <CardDescription>
-              Find and challenge suspicious submissions. If you win the challenge,
-              you'll always earn a bounty!
-            </CardDescription>
-          </CardTitleAndDescription>
-        </ClickableInfoCard>
-        <ClickableInfoCard onClick={handleRewardsClick}>
-          <RewardsIcon />
-          <CardTitleAndDescription>
-            <CardTitle>Rewards</CardTitle>
-            <CardDescription>
-              Explore active reward plans and submit compliant items to earn
-              rewards.
-            </CardDescription>
-          </CardTitleAndDescription>
-        </ClickableInfoCard>
-      </CardRow>
+      {audience === 'agent' ? (
+        <AgentGuide />
+      ) : (
+        <>
+          <Frame>
+            <SubmittingItem />
+            <ChallengingSubmission />
+            <ChallengePhase />
+          </Frame>
 
-      <ClickableInfoCard onClick={() => window.open('https://docs.kleros.io/products/curate/kleros-scout', '_blank')}>
-        <DocumentationIcon />
-        <CardTitleAndDescription>
-          <CardTitle>Documentation</CardTitle>
-          <CardDescription>
-            For more details check the full documentation.
-          </CardDescription>
-        </CardTitleAndDescription>
-      </ClickableInfoCard>
+          <CardRow>
+            <ClickableInfoCard onClick={handleRewardsClick}>
+              <BountiesIcon />
+              <CardTitleAndDescription>
+                <CardTitle>Bounties</CardTitle>
+                <CardDescription>
+                  Find and challenge suspicious submissions. If you win the challenge,
+                  you'll always earn a bounty!
+                </CardDescription>
+              </CardTitleAndDescription>
+            </ClickableInfoCard>
+            <ClickableInfoCard onClick={handleRewardsClick}>
+              <RewardsIcon />
+              <CardTitleAndDescription>
+                <CardTitle>Rewards</CardTitle>
+                <CardDescription>
+                  Explore active reward plans and submit compliant items to earn
+                  rewards.
+                </CardDescription>
+              </CardTitleAndDescription>
+            </ClickableInfoCard>
+          </CardRow>
+
+          <ClickableInfoCard onClick={() => window.open('https://docs.kleros.io/products/curate/kleros-scout', '_blank')}>
+            <DocumentationIcon />
+            <CardTitleAndDescription>
+              <CardTitle>Documentation</CardTitle>
+              <CardDescription>
+                For more details check the full documentation.
+              </CardDescription>
+            </CardTitleAndDescription>
+          </ClickableInfoCard>
+        </>
+      )}
     </Container>
   );
 };

--- a/websites/app/src/pages/Guide/index.tsx
+++ b/websites/app/src/pages/Guide/index.tsx
@@ -303,6 +303,25 @@ const AgentCommandBlock = styled.pre`
   overflow-wrap: anywhere;
 `;
 
+const AgentPromptBlock = styled.textarea`
+  width: 100%;
+  min-height: 128px;
+  resize: vertical;
+  padding: 16px;
+  border: 1px solid ${({ theme }) => theme.stroke};
+  border-radius: 8px;
+  background: #050505;
+  color: ${({ theme }) => theme.primaryText};
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  outline: none;
+
+  &:focus {
+    border-color: ${({ theme }) => theme.primaryBlue};
+  }
+`;
+
 const AgentChecklist = styled.ul`
   margin: 12px 0 0;
   padding-left: 20px;
@@ -416,6 +435,19 @@ scope:
   Scout overlay only applies to the four fixed Gnosis registries.
   If the registry address does not match, verify Curate flavor before acting.`}</AgentCommandBlock>
     </AgentTerminal>
+
+    <AgentIntro>
+      <AgentTitle>Copy-paste prompt</AgentTitle>
+      <AgentDescription>
+        Paste this into an agent that does not automatically discover Scout instructions.
+      </AgentDescription>
+      <AgentPromptBlock
+        readOnly
+        aria-label="Copy-paste prompt for agents"
+        value={`Before working on Kleros Scout, fetch and read the Scout agent instructions at ${window.location.origin}/llms.txt. Then follow the required read order in that file and do not submit, challenge, or analyze Scout registry items until the canonical kleros-skills references are loaded.`}
+        onFocus={(event) => event.currentTarget.select()}
+      />
+    </AgentIntro>
 
     <AgentIntro>
       <AgentTitle>Execution guardrails</AgentTitle>

--- a/websites/app/src/pages/Guide/index.tsx
+++ b/websites/app/src/pages/Guide/index.tsx
@@ -12,16 +12,7 @@ import WarningOutlineIcon from "svgs/icons/warning-outline.svg";
 import { hoverShortTransitionTiming } from "styles/commonStyles";
 import ScrollTop from "components/ScrollTop";
 
-const KLEROS_CURATE_SKILL_URL =
-  "https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/SKILL.md";
-const SCOUT_REGISTRIES_SKILL_URL =
-  "https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/scout-registries.md";
-const LIGHT_CURATE_SKILL_URL =
-  "https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/light-curate.md";
-
-const AGENT_QUICKSTART_COMMANDS = `curl -fsSL ${KLEROS_CURATE_SKILL_URL}
-curl -fsSL ${SCOUT_REGISTRIES_SKILL_URL}
-curl -fsSL ${LIGHT_CURATE_SKILL_URL}`;
+const SCOUT_AGENT_ENTRY_URL = "https://scout-app.kleros.io/llms-full.txt";
 
 const Container = styled.div`
   color: ${({ theme }) => theme.primaryText};
@@ -210,6 +201,33 @@ const AttentionLabel = styled.label`
   color: ${({ theme }) => theme.tintYellow};
 `;
 
+const copyTextToClipboard = async (text: string) => {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Fall back below when clipboard permission is blocked.
+  }
+
+  const textArea = document.createElement("textarea");
+  textArea.value = text;
+  textArea.setAttribute("readonly", "");
+  textArea.style.position = "fixed";
+  textArea.style.top = "-1000px";
+  textArea.style.opacity = "0";
+  document.body.appendChild(textArea);
+  textArea.focus();
+  textArea.select();
+
+  try {
+    return document.execCommand("copy");
+  } finally {
+    document.body.removeChild(textArea);
+  }
+};
+
 const AgentPanel = styled.section`
   display: flex;
   flex-direction: column;
@@ -219,43 +237,57 @@ const AgentPanel = styled.section`
   margin: 0 auto;
 `;
 
-const AgentIntro = styled.div`
-  padding: 20px;
-  border: 1px solid ${({ theme }) => theme.stroke};
-  border-radius: 8px;
-  background: ${({ theme }) => theme.lightGrey};
-`;
-
-const AgentTitle = styled.h2`
-  margin: 0 0 8px;
-  font-size: 20px;
-  color: ${({ theme }) => theme.primaryText};
-`;
-
-const AgentDescription = styled.p`
-  margin: 0;
-  color: ${({ theme }) => theme.secondaryText};
-  line-height: 1.45;
-`;
-
-const AgentPromptBlock = styled.textarea`
+const AgentLinkRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   width: 100%;
-  min-height: 128px;
-  resize: vertical;
-  padding: 16px;
-  border: 1px solid ${({ theme }) => theme.stroke};
-  border-radius: 8px;
-  background: #050505;
-  color: ${({ theme }) => theme.primaryText};
+`;
+
+const AgentInstructionsLink = styled.a`
+  min-width: 0;
+  color: inherit;
   font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
   font-size: 13px;
-  line-height: 1.5;
-  outline: none;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+`;
 
-  &:focus {
-    border-color: ${({ theme }) => theme.primaryBlue};
+const AgentCopyIconButton = styled.button`
+  ${hoverShortTransitionTiming}
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+
+  &:hover {
+    opacity: 0.7;
   }
 `;
+
+const CopyIcon = () => (
+  <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <rect x="5.5" y="2.5" width="8" height="10" rx="1.5" stroke="currentColor" />
+    <path
+      d="M3.5 5.5H3A1.5 1.5 0 0 0 1.5 7v6A1.5 1.5 0 0 0 3 14.5h5A1.5 1.5 0 0 0 9.5 13v-.5"
+      stroke="currentColor"
+      strokeLinecap="round"
+    />
+  </svg>
+);
 
 const SubmittingItem = () => (
   <SectionContainer>
@@ -324,23 +356,30 @@ const ChallengePhase = () => (
   </SectionContainer>
 );
 
-const AgentGuide = () => (
-  <AgentPanel>
-    <AgentIntro>
-      <AgentTitle>Agent quickstart</AgentTitle>
-      <AgentDescription>
-        Fetch the canonical Kleros Curate skill first, then the Scout registry and
-        Light Curate references before acting on Scout data.
-      </AgentDescription>
-      <AgentPromptBlock
-        readOnly
-        aria-label="Agent quickstart commands"
-        value={AGENT_QUICKSTART_COMMANDS}
-        onFocus={(event) => event.currentTarget.select()}
-      />
-    </AgentIntro>
-  </AgentPanel>
-);
+const AgentGuide = () => {
+  const handleCopyAgentLink = async () => {
+    await copyTextToClipboard(SCOUT_AGENT_ENTRY_URL);
+  };
+
+  return (
+    <AgentPanel>
+      <AgentLinkRow>
+        <AgentInstructionsLink href={SCOUT_AGENT_ENTRY_URL}>
+          {SCOUT_AGENT_ENTRY_URL}
+        </AgentInstructionsLink>
+        <AgentCopyIconButton
+          type="button"
+          aria-label="Copy agent link"
+          title="Copy"
+          data-agent-instructions-url={SCOUT_AGENT_ENTRY_URL}
+          onClick={handleCopyAgentLink}
+        >
+          <CopyIcon />
+        </AgentCopyIconButton>
+      </AgentLinkRow>
+    </AgentPanel>
+  );
+};
 
 const QuickGuidePage: React.FC = () => {
   const [audience, setAudience] = useState<'human' | 'agent'>('human');

--- a/websites/app/src/pages/Guide/index.tsx
+++ b/websites/app/src/pages/Guide/index.tsx
@@ -12,6 +12,17 @@ import WarningOutlineIcon from "svgs/icons/warning-outline.svg";
 import { hoverShortTransitionTiming } from "styles/commonStyles";
 import ScrollTop from "components/ScrollTop";
 
+const KLEROS_CURATE_SKILL_URL =
+  "https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/SKILL.md";
+const SCOUT_REGISTRIES_SKILL_URL =
+  "https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/scout-registries.md";
+const LIGHT_CURATE_SKILL_URL =
+  "https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/light-curate.md";
+
+const AGENT_QUICKSTART_COMMANDS = `curl -fsSL ${KLEROS_CURATE_SKILL_URL}
+curl -fsSL ${SCOUT_REGISTRIES_SKILL_URL}
+curl -fsSL ${LIGHT_CURATE_SKILL_URL}`;
+
 const Container = styled.div`
   color: ${({ theme }) => theme.primaryText};
   padding: 32px 16px 64px;
@@ -399,6 +410,20 @@ const ChallengePhase = () => (
 const AgentGuide = () => (
   <AgentPanel>
     <AgentIntro>
+      <AgentTitle>Agent quickstart</AgentTitle>
+      <AgentDescription>
+        Fetch the canonical Kleros Curate skill first, then the Scout registry and
+        Light Curate references before acting on Scout data.
+      </AgentDescription>
+      <AgentPromptBlock
+        readOnly
+        aria-label="Agent quickstart commands"
+        value={AGENT_QUICKSTART_COMMANDS}
+        onFocus={(event) => event.currentTarget.select()}
+      />
+    </AgentIntro>
+
+    <AgentIntro>
       <AgentTitle>Agent mode</AgentTitle>
       <AgentDescription>
         Fetch the machine-readable entrypoint first. Do not act on Scout submissions,
@@ -413,6 +438,10 @@ const AgentGuide = () => (
         <AgentStatus>READY</AgentStatus>
       </AgentTerminalHeader>
       <AgentEndpointList>
+        <AgentEndpoint href={KLEROS_CURATE_SKILL_URL}>
+          <AgentEndpointLabel>CANONICAL_SKILL</AgentEndpointLabel>
+          <AgentEndpointUrl>{KLEROS_CURATE_SKILL_URL}</AgentEndpointUrl>
+        </AgentEndpoint>
         <AgentEndpoint href="/llms.txt" rel="help">
           <AgentEndpointLabel>ENTRYPOINT</AgentEndpointLabel>
           <AgentEndpointUrl>/llms.txt</AgentEndpointUrl>
@@ -420,10 +449,6 @@ const AgentGuide = () => (
         <AgentEndpoint href="/scout-agent-context.md" rel="help">
           <AgentEndpointLabel>LOCAL_CONTEXT</AgentEndpointLabel>
           <AgentEndpointUrl>/scout-agent-context.md</AgentEndpointUrl>
-        </AgentEndpoint>
-        <AgentEndpoint href="https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/SKILL.md">
-          <AgentEndpointLabel>CANONICAL_SKILL</AgentEndpointLabel>
-          <AgentEndpointUrl>https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/SKILL.md</AgentEndpointUrl>
         </AgentEndpoint>
       </AgentEndpointList>
       <AgentCommandBlock>{`required_read_order:
@@ -435,22 +460,6 @@ scope:
   Scout overlay only applies to the four fixed Gnosis registries.
   If the registry address does not match, verify Curate flavor before acting.`}</AgentCommandBlock>
     </AgentTerminal>
-
-    <AgentIntro>
-      <AgentTitle>Agent quickstart</AgentTitle>
-      <AgentDescription>
-        Fetch the context directly from this deployment.
-      </AgentDescription>
-      <AgentPromptBlock
-        readOnly
-        aria-label="Agent quickstart commands"
-        value={`curl -fsSL ${window.location.origin}/skill.md
-curl -fsSL ${window.location.origin}/llms.txt
-curl -fsSL ${window.location.origin}/scout-agent-context.md
-curl -fsSL https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/SKILL.md`}
-        onFocus={(event) => event.currentTarget.select()}
-      />
-    </AgentIntro>
 
     <AgentIntro>
       <AgentTitle>Execution guardrails</AgentTitle>

--- a/websites/app/src/pages/Guide/index.tsx
+++ b/websites/app/src/pages/Guide/index.tsx
@@ -56,13 +56,10 @@ const Subtitle = styled.p`
 const AudienceSelector = styled.div`
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 12px;
   flex-wrap: wrap;
-  margin-bottom: 28px;
-  padding: 16px;
-  border: 1px solid ${({ theme }) => theme.stroke};
-  border-radius: 12px;
-  background: ${({ theme }) => theme.whiteLowOpacitySubtle};
+  margin: 0 0 32px;
 `;
 
 const SelectorLabel = styled.span`
@@ -205,15 +202,17 @@ const AttentionLabel = styled.label`
 const AgentPanel = styled.section`
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  max-width: 760px;
+  gap: 16px;
+  width: 100%;
+  max-width: 880px;
+  margin: 0 auto;
 `;
 
 const AgentIntro = styled.div`
-  padding: 24px;
+  padding: 20px;
   border: 1px solid ${({ theme }) => theme.stroke};
-  border-radius: 12px;
-  background: ${({ theme }) => theme.whiteLowOpacitySubtle};
+  border-radius: 8px;
+  background: ${({ theme }) => theme.lightGrey};
 `;
 
 const AgentTitle = styled.h2`
@@ -228,45 +227,84 @@ const AgentDescription = styled.p`
   line-height: 1.45;
 `;
 
-const AgentLinkGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 16px;
+const AgentTerminal = styled.div`
+  border: 1px solid ${({ theme }) => theme.stroke};
+  border-radius: 8px;
+  background: #050505;
+  overflow: hidden;
 `;
 
-const AgentLinkCard = styled.a`
-  ${hoverShortTransitionTiming}
+const AgentTerminalHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid ${({ theme }) => theme.stroke};
+  color: ${({ theme }) => theme.secondaryText};
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 12px;
+`;
+
+const AgentStatus = styled.span`
+  color: ${({ theme }) => theme.success};
+`;
+
+const AgentEndpointList = styled.div`
   display: flex;
   flex-direction: column;
+`;
+
+const AgentEndpoint = styled.a`
+  ${hoverShortTransitionTiming}
+  display: grid;
+  grid-template-columns: 1fr;
   gap: 8px;
-  padding: 20px;
-  min-height: 132px;
-  border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.stroke};
+  padding: 16px;
+  border-bottom: 1px solid ${({ theme }) => theme.stroke};
   color: ${({ theme }) => theme.primaryText};
   text-decoration: none;
-  background: transparent;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 14px;
+
+  &:last-child {
+    border-bottom: 0;
+  }
 
   &:hover {
-    transform: scale(1.02);
-    border-color: ${({ theme }) => theme.primary};
-    box-shadow: ${({ theme }) => theme.shadowDropdown};
+    background: ${({ theme }) => theme.whiteLowOpacitySubtle};
   }
+
+  ${landscapeStyle(
+    () => css`
+      grid-template-columns: 210px 1fr;
+      gap: 16px;
+    `
+  )}
 `;
 
-const AgentLinkTitle = styled.span`
-  font-size: 16px;
-  font-weight: 600;
+const AgentEndpointLabel = styled.span`
+  color: ${({ theme }) => theme.primaryBlue};
 `;
 
-const AgentLinkDescription = styled.span`
-  color: ${({ theme }) => theme.tertiaryText};
-  font-size: 14px;
-  line-height: 1.35;
+const AgentEndpointUrl = styled.span`
+  color: ${({ theme }) => theme.secondaryText};
+  overflow-wrap: anywhere;
+`;
+
+const AgentCommandBlock = styled.pre`
+  margin: 0;
+  padding: 16px;
+  color: ${({ theme }) => theme.secondaryText};
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 13px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 `;
 
 const AgentChecklist = styled.ul`
-  margin: 0;
+  margin: 12px 0 0;
   padding-left: 20px;
   color: ${({ theme }) => theme.secondaryText};
   line-height: 1.45;
@@ -342,37 +380,45 @@ const ChallengePhase = () => (
 const AgentGuide = () => (
   <AgentPanel>
     <AgentIntro>
-      <AgentTitle>I am an agent.</AgentTitle>
+      <AgentTitle>Agent mode</AgentTitle>
       <AgentDescription>
-        Start with the machine-readable instructions, then load the canonical Kleros Curate
-        skill references before acting on Scout submissions, challenges, evidence, appeals,
-        registry data, token lists, address tags, or CDN mappings.
+        Fetch the machine-readable entrypoint first. Do not act on Scout submissions,
+        challenges, evidence, appeals, registry data, token lists, address tags, or CDN
+        mappings until the canonical Kleros Curate references are loaded.
       </AgentDescription>
     </AgentIntro>
 
-    <AgentLinkGrid>
-      <AgentLinkCard href="/llms.txt" rel="help">
-        <AgentLinkTitle>Start here: /llms.txt</AgentLinkTitle>
-        <AgentLinkDescription>
-          Short Scout-specific entrypoint with required read order and safety rules.
-        </AgentLinkDescription>
-      </AgentLinkCard>
-      <AgentLinkCard href="/scout-agent-context.md" rel="help">
-        <AgentLinkTitle>Expanded Scout context</AgentLinkTitle>
-        <AgentLinkDescription>
-          Local workflow guide for the four supported Scout registries on Gnosis.
-        </AgentLinkDescription>
-      </AgentLinkCard>
-      <AgentLinkCard href="https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/SKILL.md">
-        <AgentLinkTitle>Canonical Kleros Curate skill</AgentLinkTitle>
-        <AgentLinkDescription>
-          Source of truth if any local Scout guidance conflicts with kleros-skills.
-        </AgentLinkDescription>
-      </AgentLinkCard>
-    </AgentLinkGrid>
+    <AgentTerminal>
+      <AgentTerminalHeader>
+        <span>SCOUT_AGENT_CONTEXT</span>
+        <AgentStatus>READY</AgentStatus>
+      </AgentTerminalHeader>
+      <AgentEndpointList>
+        <AgentEndpoint href="/llms.txt" rel="help">
+          <AgentEndpointLabel>ENTRYPOINT</AgentEndpointLabel>
+          <AgentEndpointUrl>/llms.txt</AgentEndpointUrl>
+        </AgentEndpoint>
+        <AgentEndpoint href="/scout-agent-context.md" rel="help">
+          <AgentEndpointLabel>LOCAL_CONTEXT</AgentEndpointLabel>
+          <AgentEndpointUrl>/scout-agent-context.md</AgentEndpointUrl>
+        </AgentEndpoint>
+        <AgentEndpoint href="https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/SKILL.md">
+          <AgentEndpointLabel>CANONICAL_SKILL</AgentEndpointLabel>
+          <AgentEndpointUrl>https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/SKILL.md</AgentEndpointUrl>
+        </AgentEndpoint>
+      </AgentEndpointList>
+      <AgentCommandBlock>{`required_read_order:
+  1. kleros-curate/SKILL.md
+  2. references/scout-registries.md
+  3. references/light-curate.md
+
+scope:
+  Scout overlay only applies to the four fixed Gnosis registries.
+  If the registry address does not match, verify Curate flavor before acting.`}</AgentCommandBlock>
+    </AgentTerminal>
 
     <AgentIntro>
-      <AgentTitle>Do not proceed until these checks pass.</AgentTitle>
+      <AgentTitle>Execution guardrails</AgentTitle>
       <AgentChecklist>
         <li>Confirm the registry is one of the four Scout registry addresses.</li>
         <li>Read scout-registries.md and light-curate.md together.</li>

--- a/websites/app/src/pages/Guide/index.tsx
+++ b/websites/app/src/pages/Guide/index.tsx
@@ -13,6 +13,7 @@ import { hoverShortTransitionTiming } from "styles/commonStyles";
 import ScrollTop from "components/ScrollTop";
 
 const SCOUT_AGENT_ENTRY_URL = "https://scout-app.kleros.io/llms-full.txt";
+const SCOUT_AGENT_PROMPT = `Read ${SCOUT_AGENT_ENTRY_URL} and follow it before interacting with Kleros Scout.`;
 
 const Container = styled.div`
   color: ${({ theme }) => theme.primaryText};
@@ -211,6 +212,22 @@ const copyTextToClipboard = async (text: string) => {
     // Fall back below when clipboard permission is blocked.
   }
 
+  let didCopy = false;
+  const handleCopy = (event: ClipboardEvent) => {
+    event.clipboardData?.setData("text/plain", text);
+    event.preventDefault();
+    didCopy = true;
+  };
+
+  document.addEventListener("copy", handleCopy);
+  try {
+    didCopy = document.execCommand("copy") || didCopy;
+  } finally {
+    document.removeEventListener("copy", handleCopy);
+  }
+
+  if (didCopy) return true;
+
   const textArea = document.createElement("textarea");
   textArea.value = text;
   textArea.setAttribute("readonly", "");
@@ -237,35 +254,102 @@ const AgentPanel = styled.section`
   margin: 0 auto;
 `;
 
-const AgentLinkRow = styled.div`
+const AgentPromptCard = styled.div`
   display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  width: 100%;
+  flex-direction: column;
+  gap: 18px;
+  padding: 24px;
+  border: 1px solid ${({ theme }) => theme.stroke};
+  border-radius: 8px;
 `;
 
-const AgentInstructionsLink = styled.a`
-  min-width: 0;
-  color: inherit;
+const AgentPromptHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+`;
+
+const AgentPromptTitle = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: ${({ theme }) => theme.primaryBlue};
   font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
   font-size: 13px;
-  line-height: 1.4;
+  font-weight: 700;
+  text-transform: uppercase;
+`;
+
+const AgentPromptStep = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  font-size: 12px;
+`;
+
+const AgentPromptMeta = styled.span`
+  color: ${({ theme }) => theme.secondaryText};
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 13px;
+`;
+
+const AgentPromptRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 18px;
+  border: 1px solid ${({ theme }) => theme.stroke};
+  border-radius: 8px;
+  background: ${({ theme }) => theme.lightGrey};
+
+  ${landscapeStyle(
+    () => css`
+      padding: 20px;
+    `
+  )}
+`;
+
+const AgentPromptText = styled.code`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: ${({ theme }) => theme.primaryText};
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 14px;
+  line-height: 1.5;
   overflow-wrap: anywhere;
 `;
 
-const AgentCopyIconButton = styled.button`
+const AgentPromptMarker = styled.span`
+  color: ${({ theme }) => theme.primaryBlue};
+  font-weight: 700;
+`;
+
+const AgentCopyButton = styled.button`
   ${hoverShortTransitionTiming}
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  border: 0;
+  min-height: 40px;
+  padding: 8px 12px;
+  border: 1px solid ${({ theme }) => theme.stroke};
+  border-radius: 7px;
   background: transparent;
-  color: inherit;
+  color: ${({ theme }) => theme.primaryText};
+  font: inherit;
+  font-size: 14px;
+  font-weight: 600;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 8px;
   flex-shrink: 0;
 
   svg {
@@ -274,7 +358,8 @@ const AgentCopyIconButton = styled.button`
   }
 
   &:hover {
-    opacity: 0.7;
+    border-color: ${({ theme }) => theme.primaryBlue};
+    color: ${({ theme }) => theme.primaryBlue};
   }
 `;
 
@@ -357,26 +442,38 @@ const ChallengePhase = () => (
 );
 
 const AgentGuide = () => {
-  const handleCopyAgentLink = async () => {
-    await copyTextToClipboard(SCOUT_AGENT_ENTRY_URL);
+  const handleCopyAgentPrompt = async () => {
+    await copyTextToClipboard(SCOUT_AGENT_PROMPT);
   };
 
   return (
     <AgentPanel>
-      <AgentLinkRow>
-        <AgentInstructionsLink href={SCOUT_AGENT_ENTRY_URL}>
-          {SCOUT_AGENT_ENTRY_URL}
-        </AgentInstructionsLink>
-        <AgentCopyIconButton
-          type="button"
-          aria-label="Copy agent link"
-          title="Copy"
-          data-agent-instructions-url={SCOUT_AGENT_ENTRY_URL}
-          onClick={handleCopyAgentLink}
-        >
-          <CopyIcon />
-        </AgentCopyIconButton>
-      </AgentLinkRow>
+      <AgentPromptCard>
+        <AgentPromptHeader>
+          <AgentPromptTitle>
+            <AgentPromptStep>1</AgentPromptStep>
+            Paste this into your agent
+          </AgentPromptTitle>
+          <AgentPromptMeta>One line · works in any agent</AgentPromptMeta>
+        </AgentPromptHeader>
+
+        <AgentPromptRow>
+          <AgentPromptText>
+            <AgentPromptMarker>&gt;</AgentPromptMarker>
+            <span>{SCOUT_AGENT_PROMPT}</span>
+          </AgentPromptText>
+          <AgentCopyButton
+            type="button"
+            aria-label="Copy agent prompt"
+            data-agent-instructions-url={SCOUT_AGENT_ENTRY_URL}
+            data-agent-prompt={SCOUT_AGENT_PROMPT}
+            onClick={handleCopyAgentPrompt}
+          >
+            <CopyIcon />
+            Copy prompt
+          </AgentCopyButton>
+        </AgentPromptRow>
+      </AgentPromptCard>
     </AgentPanel>
   );
 };
@@ -395,7 +492,7 @@ const QuickGuidePage: React.FC = () => {
       <Header>
         <BookCircleIcon />
         <div>
-          <Title>Learn · AI</Title>
+          <Title>Guide & Skills</Title>
           <Subtitle>
             Keep the community safe, earn bounties, and have fun in Kleros Scout!
           </Subtitle>

--- a/websites/app/src/pages/Guide/index.tsx
+++ b/websites/app/src/pages/Guide/index.tsx
@@ -238,82 +238,6 @@ const AgentDescription = styled.p`
   line-height: 1.45;
 `;
 
-const AgentTerminal = styled.div`
-  border: 1px solid ${({ theme }) => theme.stroke};
-  border-radius: 8px;
-  background: #050505;
-  overflow: hidden;
-`;
-
-const AgentTerminalHeader = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px 16px;
-  border-bottom: 1px solid ${({ theme }) => theme.stroke};
-  color: ${({ theme }) => theme.secondaryText};
-  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
-  font-size: 12px;
-`;
-
-const AgentStatus = styled.span`
-  color: ${({ theme }) => theme.success};
-`;
-
-const AgentEndpointList = styled.div`
-  display: flex;
-  flex-direction: column;
-`;
-
-const AgentEndpoint = styled.a`
-  ${hoverShortTransitionTiming}
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 8px;
-  padding: 16px;
-  border-bottom: 1px solid ${({ theme }) => theme.stroke};
-  color: ${({ theme }) => theme.primaryText};
-  text-decoration: none;
-  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
-  font-size: 14px;
-
-  &:last-child {
-    border-bottom: 0;
-  }
-
-  &:hover {
-    background: ${({ theme }) => theme.whiteLowOpacitySubtle};
-  }
-
-  ${landscapeStyle(
-    () => css`
-      grid-template-columns: 210px 1fr;
-      gap: 16px;
-    `
-  )}
-`;
-
-const AgentEndpointLabel = styled.span`
-  color: ${({ theme }) => theme.primaryBlue};
-`;
-
-const AgentEndpointUrl = styled.span`
-  color: ${({ theme }) => theme.secondaryText};
-  overflow-wrap: anywhere;
-`;
-
-const AgentCommandBlock = styled.pre`
-  margin: 0;
-  padding: 16px;
-  color: ${({ theme }) => theme.secondaryText};
-  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
-  font-size: 13px;
-  line-height: 1.55;
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-`;
-
 const AgentPromptBlock = styled.textarea`
   width: 100%;
   min-height: 128px;
@@ -331,13 +255,6 @@ const AgentPromptBlock = styled.textarea`
   &:focus {
     border-color: ${({ theme }) => theme.primaryBlue};
   }
-`;
-
-const AgentChecklist = styled.ul`
-  margin: 12px 0 0;
-  padding-left: 20px;
-  color: ${({ theme }) => theme.secondaryText};
-  line-height: 1.45;
 `;
 
 const SubmittingItem = () => (
@@ -421,54 +338,6 @@ const AgentGuide = () => (
         value={AGENT_QUICKSTART_COMMANDS}
         onFocus={(event) => event.currentTarget.select()}
       />
-    </AgentIntro>
-
-    <AgentIntro>
-      <AgentTitle>Agent mode</AgentTitle>
-      <AgentDescription>
-        Fetch the machine-readable entrypoint first. Do not act on Scout submissions,
-        challenges, evidence, appeals, registry data, token lists, address tags, or CDN
-        mappings until the canonical Kleros Curate references are loaded.
-      </AgentDescription>
-    </AgentIntro>
-
-    <AgentTerminal>
-      <AgentTerminalHeader>
-        <span>SCOUT_AGENT_CONTEXT</span>
-        <AgentStatus>READY</AgentStatus>
-      </AgentTerminalHeader>
-      <AgentEndpointList>
-        <AgentEndpoint href={KLEROS_CURATE_SKILL_URL}>
-          <AgentEndpointLabel>CANONICAL_SKILL</AgentEndpointLabel>
-          <AgentEndpointUrl>{KLEROS_CURATE_SKILL_URL}</AgentEndpointUrl>
-        </AgentEndpoint>
-        <AgentEndpoint href="/llms.txt" rel="help">
-          <AgentEndpointLabel>ENTRYPOINT</AgentEndpointLabel>
-          <AgentEndpointUrl>/llms.txt</AgentEndpointUrl>
-        </AgentEndpoint>
-        <AgentEndpoint href="/scout-agent-context.md" rel="help">
-          <AgentEndpointLabel>LOCAL_CONTEXT</AgentEndpointLabel>
-          <AgentEndpointUrl>/scout-agent-context.md</AgentEndpointUrl>
-        </AgentEndpoint>
-      </AgentEndpointList>
-      <AgentCommandBlock>{`required_read_order:
-  1. kleros-curate/SKILL.md
-  2. references/scout-registries.md
-  3. references/light-curate.md
-
-scope:
-  Scout overlay only applies to the four fixed Gnosis registries.
-  If the registry address does not match, verify Curate flavor before acting.`}</AgentCommandBlock>
-    </AgentTerminal>
-
-    <AgentIntro>
-      <AgentTitle>Execution guardrails</AgentTitle>
-      <AgentChecklist>
-        <li>Confirm the registry is one of the four Scout registry addresses.</li>
-        <li>Read scout-registries.md and light-curate.md together.</li>
-        <li>Use Scout seed templates first, then cross-check current MetaEvidence.</li>
-        <li>Read the current policy and compute deposits from fresh onchain reads.</li>
-      </AgentChecklist>
     </AgentIntro>
   </AgentPanel>
 );

--- a/websites/app/src/public/.well-known/llms.txt
+++ b/websites/app/src/public/.well-known/llms.txt
@@ -1,0 +1,17 @@
+# Kleros Scout llms.txt
+
+This well-known mirror exists for agent discovery.
+
+Canonical instructions:
+
+https://scout-app.kleros.io/llms.txt
+
+Full Scout agent entrypoint:
+
+https://scout-app.kleros.io/llms-full.txt
+
+Required read order:
+
+1. https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/SKILL.md
+2. https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/scout-registries.md
+3. https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/light-curate.md

--- a/websites/app/src/public/_headers
+++ b/websites/app/src/public/_headers
@@ -1,0 +1,3 @@
+/*
+  Link: </llms.txt>; rel="alternate"; type="text/plain"; title="Scout agent instructions"
+  Link: </scout-agent-context.md>; rel="help"; type="text/markdown"; title="Scout agent context"

--- a/websites/app/src/public/_headers
+++ b/websites/app/src/public/_headers
@@ -1,3 +1,27 @@
 /*
   Link: </llms.txt>; rel="alternate"; type="text/plain"; title="Scout agent instructions"
+  Link: </llms-full.txt>; rel="help"; type="text/plain"; title="Scout full agent context"
   Link: </scout-agent-context.md>; rel="help"; type="text/markdown"; title="Scout agent context"
+
+/robots.txt
+  Content-Type: text/plain; charset=utf-8
+  X-Robots-Tag: index, follow
+
+/llms.txt
+  Content-Type: text/plain; charset=utf-8
+  X-Robots-Tag: index, follow
+  Link: <https://scout-app.kleros.io/llms.txt>; rel="canonical"; type="text/plain"; title="Scout agent instructions"
+
+/.well-known/llms.txt
+  Content-Type: text/plain; charset=utf-8
+  X-Robots-Tag: index, follow
+  Link: <https://scout-app.kleros.io/llms.txt>; rel="canonical"; type="text/plain"; title="Scout agent instructions"
+
+/llms-full.txt
+  Content-Type: text/plain; charset=utf-8
+  X-Robots-Tag: index, follow
+  Link: <https://scout-app.kleros.io/llms-full.txt>; rel="canonical"; type="text/plain"; title="Scout full agent context"
+
+/scout-agent-context.md
+  Content-Type: text/markdown; charset=utf-8
+  X-Robots-Tag: index, follow

--- a/websites/app/src/public/_redirects
+++ b/websites/app/src/public/_redirects
@@ -1,4 +1,6 @@
 /.well-known/llms.txt    /llms.txt                   200
+/skill.md                /llms.txt                   200
+/agent.md                /scout-agent-context.md     200
 /agent-context.md        /scout-agent-context.md     200
 /llms-full.txt           /scout-agent-context.md     200
 

--- a/websites/app/src/public/_redirects
+++ b/websites/app/src/public/_redirects
@@ -1,1 +1,5 @@
+/.well-known/llms.txt    /llms.txt                   200
+/agent-context.md        /scout-agent-context.md     200
+/llms-full.txt           /scout-agent-context.md     200
+
 /*    /index.html   200

--- a/websites/app/src/public/_redirects
+++ b/websites/app/src/public/_redirects
@@ -1,5 +1,7 @@
 /.well-known/llms.txt    /llms.txt                   200
-/skill.md                /llms.txt                   200
+/skill.md                https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/SKILL.md                                      302
+/skill/scout-registries.md    https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/scout-registries.md        302
+/skill/light-curate.md        https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/light-curate.md              302
 /agent.md                /scout-agent-context.md     200
 /agent-context.md        /scout-agent-context.md     200
 /llms-full.txt           /scout-agent-context.md     200

--- a/websites/app/src/public/_redirects
+++ b/websites/app/src/public/_redirects
@@ -1,9 +1,7 @@
-/.well-known/llms.txt    /llms.txt                   200
 /skill.md                https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/SKILL.md                                      302
 /skill/scout-registries.md    https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/scout-registries.md        302
 /skill/light-curate.md        https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/light-curate.md              302
-/agent.md                /scout-agent-context.md     200
-/agent-context.md        /scout-agent-context.md     200
-/llms-full.txt           /scout-agent-context.md     200
+/agent.md                /llms-full.txt              200
+/agent-context.md        /llms-full.txt              200
 
 /*    /index.html   200

--- a/websites/app/src/public/llms-full.txt
+++ b/websites/app/src/public/llms-full.txt
@@ -1,0 +1,48 @@
+# Kleros Scout Agent Entry
+
+Summary: Kleros Scout is a UI for four fixed Gnosis Chain Kleros Curate LightGeneralizedTCR registries. Agents must load the Curate skill, Scout registry rules, and Light Curate contract operations before submitting, challenging, removing, appealing, or analyzing Scout registry items.
+
+Canonical Scout site:
+
+https://scout-app.kleros.io/
+
+Start here:
+
+1. Kleros Curate skill:
+   https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/SKILL.md
+
+2. Scout registry rules:
+   https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/scout-registries.md
+
+3. Light Curate contract operations:
+   https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/light-curate.md
+
+Scout registry scope:
+
+`scout-registries.md` applies only to these four Gnosis Chain registries:
+
+- ATQ / Address Tags Query: `0xAe6aaed5434244be3699c56E7Ebc828194F26dc3`
+- Address Tags: `0x66260C69d03837016d88c9877e61e08Ef74C59F2`
+- Kleros Tokens: `0xeE1502e29795Ef6C2D60F8D7120596abE3baD990`
+- CDN / Contract Domain Names: `0x957A53A994860BE4750810131d9c876b2f52d6E1`
+
+If a registry address is not one of those four, do not use Scout seed templates or Scout-only assumptions. Verify the Curate flavor first.
+
+Task routing:
+
+- Scout submissions: read `SKILL.md`, `scout-registries.md`, and `light-curate.md`; use the Scout seed template; fetch current MetaEvidence; read the registry policy; compute the live deposit; simulate before submitting.
+- Scout challenges, removals, evidence, and appeals: read `SKILL.md`, `scout-registries.md`, and `light-curate.md`; verify the current policy and request state before acting.
+- Item JSON and image fields: use the Scout seed template first, then cross-check current MetaEvidence. Do not change `item.json.columns`; only populate `values`.
+- Contract calls and deposits: use `light-curate.md` and fresh onchain reads. Do not guess deposits, arbitration costs, challenge windows, policies, addresses, or schemas.
+
+Supporting references:
+
+- MetaEvidence: https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-metaevidence.md
+- item.json construction: https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-item-json.md
+- Deposits: https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-deposits.md
+- IPFS upload: https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-ipfs-upload.md
+- ABI fragments: https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-abi-fragments.md
+
+Conflict rule:
+
+If this file conflicts with the canonical `kleros-skills` repository, follow `kleros-skills`.

--- a/websites/app/src/public/llms.txt
+++ b/websites/app/src/public/llms.txt
@@ -1,38 +1,28 @@
-# Kleros Scout Agent Instructions
+# Kleros Scout llms.txt
 
-Scout is a Kleros Curate interface for fixed Gnosis Chain registries. Scout is not a separate contract type: it uses LightGeneralizedTCR contracts.
+Summary: Kleros Scout is a UI for four fixed Gnosis Chain Kleros Curate LightGeneralizedTCR registries. Agents must read Scout-specific registry context before acting on submissions, challenges, removals, evidence, appeals, registry data, token lists, address tags, or CDN mappings.
 
-For expanded local context, read:
+Start here:
 
-/scout-agent-context.md
+1. Full Scout agent entrypoint: https://scout-app.kleros.io/llms-full.txt
+2. Canonical Curate skill: https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/SKILL.md
+3. Scout registry rules: https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/scout-registries.md
+4. Light Curate operations: https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/light-curate.md
 
-When working with Scout submissions, challenges, evidence, appeals, registry data, token lists, address tags, or CDN mappings, read these files before acting:
+Task routing:
 
-1. https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/SKILL.md
-2. https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/scout-registries.md
-3. https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/light-curate.md
+- Scout submissions: read `llms-full.txt`, then `SKILL.md`, `scout-registries.md`, and `light-curate.md`.
+- Scout challenges, removals, evidence, and appeals: read `llms-full.txt`, then verify the current registry policy and request state.
+- Registry schemas, seed templates, image rules, and Scout-specific addresses: use `scout-registries.md`.
+- LightGeneralizedTCR contract calls, deposits, requests, evidence, appeals, and execution: use `light-curate.md`.
 
-Scout-specific rules:
+Scope:
 
-- Treat Scout as Light Curate on Gnosis, chainId 100.
-- `scout-registries.md` applies only to these four Scout registries on Gnosis:
-  - ATQ / Address Tags Query: `0xAe6aaed5434244be3699c56E7Ebc828194F26dc3`
-  - Address Tags: `0x66260C69d03837016d88c9877e61e08Ef74C59F2`
-  - Kleros Tokens: `0xeE1502e29795Ef6C2D60F8D7120596abE3baD990`
-  - CDN / Contract Domain Names: `0x957A53A994860BE4750810131d9c876b2f52d6E1`
-- If the registry is not one of those four addresses, do not use Scout seed templates. Treat it as normal Light Curate unless another Curate flavor is verified.
-- Use `scout-registries.md` for Scout registry addresses, seed templates, Scout-specific image requirements, and submission checklist.
-- Use `light-curate.md` for all LightGeneralizedTCR contract operations.
-- Do not infer item schemas from memory. Use the Scout seed template, then cross-check against current MetaEvidence.
-- Do not guess deposits, arbitration costs, challenge windows, policies, addresses, or field schemas.
-- Read the current policy before deciding whether an item is valid.
-- Compute deposits from live onchain reads before submitting transactions.
-- If this file conflicts with `kleros-skills`, the canonical `kleros-skills` files win.
+`scout-registries.md` is valid only for these four Gnosis Chain registries:
 
-Useful task references:
+- ATQ / Address Tags Query: `0xAe6aaed5434244be3699c56E7Ebc828194F26dc3`
+- Address Tags: `0x66260C69d03837016d88c9877e61e08Ef74C59F2`
+- Kleros Tokens: `0xeE1502e29795Ef6C2D60F8D7120596abE3baD990`
+- CDN / Contract Domain Names: `0x957A53A994860BE4750810131d9c876b2f52d6E1`
 
-- MetaEvidence: https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-metaevidence.md
-- item.json construction: https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-item-json.md
-- Deposits: https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-deposits.md
-- IPFS upload: https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-ipfs-upload.md
-- ABI fragments: https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-abi-fragments.md
+If a registry address is not one of those four, do not apply Scout seed templates or Scout-only assumptions. Verify the Curate flavor first.

--- a/websites/app/src/public/llms.txt
+++ b/websites/app/src/public/llms.txt
@@ -1,0 +1,38 @@
+# Kleros Scout Agent Instructions
+
+Scout is a Kleros Curate interface for fixed Gnosis Chain registries. Scout is not a separate contract type: it uses LightGeneralizedTCR contracts.
+
+For expanded local context, read:
+
+https://scout.kleros.io/scout-agent-context.md
+
+When working with Scout submissions, challenges, evidence, appeals, registry data, token lists, address tags, or CDN mappings, read these files before acting:
+
+1. https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/SKILL.md
+2. https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/scout-registries.md
+3. https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/light-curate.md
+
+Scout-specific rules:
+
+- Treat Scout as Light Curate on Gnosis, chainId 100.
+- `scout-registries.md` applies only to these four Scout registries on Gnosis:
+  - ATQ / Address Tags Query: `0xAe6aaed5434244be3699c56E7Ebc828194F26dc3`
+  - Address Tags: `0x66260C69d03837016d88c9877e61e08Ef74C59F2`
+  - Kleros Tokens: `0xeE1502e29795Ef6C2D60F8D7120596abE3baD990`
+  - CDN / Contract Domain Names: `0x957A53A994860BE4750810131d9c876b2f52d6E1`
+- If the registry is not one of those four addresses, do not use Scout seed templates. Treat it as normal Light Curate unless another Curate flavor is verified.
+- Use `scout-registries.md` for Scout registry addresses, seed templates, Scout-specific image requirements, and submission checklist.
+- Use `light-curate.md` for all LightGeneralizedTCR contract operations.
+- Do not infer item schemas from memory. Use the Scout seed template, then cross-check against current MetaEvidence.
+- Do not guess deposits, arbitration costs, challenge windows, policies, addresses, or field schemas.
+- Read the current policy before deciding whether an item is valid.
+- Compute deposits from live onchain reads before submitting transactions.
+- If this file conflicts with `kleros-skills`, the canonical `kleros-skills` files win.
+
+Useful task references:
+
+- MetaEvidence: https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-metaevidence.md
+- item.json construction: https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-item-json.md
+- Deposits: https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-deposits.md
+- IPFS upload: https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-ipfs-upload.md
+- ABI fragments: https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-abi-fragments.md

--- a/websites/app/src/public/llms.txt
+++ b/websites/app/src/public/llms.txt
@@ -4,7 +4,7 @@ Scout is a Kleros Curate interface for fixed Gnosis Chain registries. Scout is n
 
 For expanded local context, read:
 
-https://scout.kleros.io/scout-agent-context.md
+/scout-agent-context.md
 
 When working with Scout submissions, challenges, evidence, appeals, registry data, token lists, address tags, or CDN mappings, read these files before acting:
 

--- a/websites/app/src/public/robots.txt
+++ b/websites/app/src/public/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+
+# Agent instructions:
+# https://scout-app.kleros.io/llms.txt
+# https://scout-app.kleros.io/llms-full.txt

--- a/websites/app/src/public/scout-agent-context.md
+++ b/websites/app/src/public/scout-agent-context.md
@@ -1,0 +1,70 @@
+# Scout Agent Context
+
+This page tells AI agents how to work safely with Kleros Scout.
+
+Scout is an overlay on Kleros Curate LightGeneralizedTCR contracts deployed on Gnosis Chain. It is not a separate contract type. Any agent working on Scout must combine Scout-specific registry context with Light Curate contract operations.
+
+## Required Read Order
+
+Read these before submitting, challenging, removing, appealing, or analyzing Scout registry items:
+
+1. Kleros Curate skill:
+   https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/SKILL.md
+
+2. Scout registry context:
+   https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/scout-registries.md
+
+3. Light Curate contract operations:
+   https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/light-curate.md
+
+## Non-Negotiable Rules
+
+- Never guess addresses, schemas, field ordering, policies, deposits, arbitration costs, or challenge windows.
+- Scout registries are on Gnosis Chain, chainId 100.
+- Scout uses LightGeneralizedTCR contracts.
+- `scout-registries.md` is valid only for these four Scout registries:
+  - ATQ / Address Tags Query: `0xAe6aaed5434244be3699c56E7Ebc828194F26dc3`
+  - Address Tags: `0x66260C69d03837016d88c9877e61e08Ef74C59F2`
+  - Kleros Tokens: `0xeE1502e29795Ef6C2D60F8D7120596abE3baD990`
+  - CDN / Contract Domain Names: `0x957A53A994860BE4750810131d9c876b2f52d6E1`
+- If a registry address is not one of those four, do not apply Scout seed templates or Scout-only assumptions. Verify the contract type and proceed with the appropriate Curate reference.
+- Use Scout seed templates first, then cross-check with current MetaEvidence.
+- Do not change `item.json.columns`; only populate `values`.
+- Read the current registry policy before deciding whether a submission is compliant.
+- Compute all deposits from fresh onchain reads.
+- Simulate transactions before submitting them.
+- If Scout guidance conflicts with the canonical `kleros-skills` repository, follow `kleros-skills`.
+
+## Scout Workflows
+
+For Scout submissions:
+
+1. Identify the target Scout registry.
+2. Load the correct seed template from `scout-registries.md`.
+3. Replace all placeholders with real values.
+4. Fetch the latest MetaEvidence.
+5. Cross-check labels, ordering, required fields, and field types.
+6. Read the registry policy.
+7. Upload any required images or item JSON to IPFS.
+8. Compute the live deposit.
+9. Simulate the transaction.
+10. Submit only if all checks pass.
+
+For contract operations, use `light-curate.md`.
+
+For supporting details, use:
+
+- MetaEvidence:
+  https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-metaevidence.md
+
+- item.json:
+  https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-item-json.md
+
+- Deposits:
+  https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-deposits.md
+
+- IPFS:
+  https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-ipfs-upload.md
+
+- ABI fragments:
+  https://raw.githubusercontent.com/kleros/kleros-skills/master/kleros-curate/references/shared-abi-fragments.md


### PR DESCRIPTION
## Summary
- add /llms.txt as an agent-readable Scout guidance entrypoint
- add /scout-agent-context.md with expanded safety rules and required kleros-skills references
- expose agent guidance from every app route via HTML head links and common aliases
- add a visible footer link to Agent instructions
- rename Quick Guide to Learn · AI and add a Human/Agent selector on the guide page
- document that Scout-specific guidance only applies to the four fixed Gnosis registries

## Test
- cd websites/app && corepack yarn wagmi generate && corepack yarn build
- local browser smoke test for /guide human and agent states at desktop and mobile widths
